### PR TITLE
chore(inventory-update): disable konnectivity flag

### DIFF
--- a/inventory/samples/single-node-lvm.sample.yaml
+++ b/inventory/samples/single-node-lvm.sample.yaml
@@ -35,4 +35,5 @@ k0s:
       vars:
         # --no-taints removes node-role.kubernetes.io/master taint
         # so that k8s workloads can be provisioned on the controller node
-        extra_args: "--enable-worker --no-taints"
+        # konnectivity-server is not required in a one node flat network cluster
+        extra_args: "--enable-worker --no-taints --disable-components konnectivity-server"

--- a/inventory/samples/single-node.sample.yaml
+++ b/inventory/samples/single-node.sample.yaml
@@ -32,4 +32,5 @@ k0s:
       vars:
         # --no-taints removes node-role.kubernetes.io/master taint
         # so that k8s workloads can be provisioned on the controller node
-        extra_args: "--enable-worker --no-taints"
+        # konnectivity-server is not required in a one node flat network cluster
+        extra_args: "--enable-worker --no-taints --disable-components konnectivity-server"


### PR DESCRIPTION
fixes connectivity issues related with displaying `logs`, `port-forwarding` or `exec-ing` into pods - similar to https://github.com/k0sproject/k0s/issues/1352#issuecomment-994350579 . This was missed during testing as most of the application testing was done on an HA cluster