### PR TITLE
fix(taskfile): fix name selector for releases:apply

### DIFF
--- a/taskfiles/scripts/helmfile.sh
+++ b/taskfiles/scripts/helmfile.sh
@@ -16,7 +16,7 @@ if [[ -z "$SELECTOR" ]] && [[ "$#" -gt 0 ]]; then
     SELECTOR+="--selector="
 fi
 
-IFS="," SELECTOR+=$(echo "$*")
+IFS="" SELECTOR+=$(echo "$*")
 
 set -e
 


### PR DESCRIPTION
Without fix:
```
task releases:apply -- superset superset-postgresql
task: [releases:apply] taskfiles/scripts/helmfile.sh apply superset superset-postgresql
+ '[' apply = apply ']'
+ helmfile --interactive -f '' --skip-diff-on-install --selector=namespace=superset name=superset-postgresql apply
unknown command "name=superset-postgresql" for "helmfile"
task: Failed to run task "releases:apply": exit status 3
```

With fix:
```
task releases:apply -- superset superset-postgresql
task: [releases:apply] taskfiles/scripts/helmfile.sh apply superset superset-postgresql
+ '[' apply = apply ']'
+ helmfile --interactive -f '' --skip-diff-on-install --selector=namespace=superset,name=superset-postgresql apply
...
```